### PR TITLE
Accessible shop entries

### DIFF
--- a/src/main/java/dev/doctor4t/trainmurdermystery/game/GameConstants.java
+++ b/src/main/java/dev/doctor4t/trainmurdermystery/game/GameConstants.java
@@ -75,8 +75,6 @@ public interface GameConstants {
     int ITEM_PSYCHOSIS_REROLL_TIME = 200;
 
     // Shop Variables
-
-    // Now accessible to the people (me)
     List<ShopEntry> SHOP_ENTRIES = Util.make(new ArrayList<>(), entries -> {
         entries.add(new ShopEntry(TMMItems.KNIFE.getDefaultStack(), 100, ShopEntry.Type.WEAPON));
         entries.add(new ShopEntry(TMMItems.REVOLVER.getDefaultStack(), 300, ShopEntry.Type.WEAPON));


### PR DESCRIPTION
A super tiny PR that makes GameConstants.SHOP_ENTRIES accessible.

(This is for the modders AKA me)
Example Use:
`SHOP_ENTRIES.add(4, new ShopEntry(YOUR_ITEM.getDefaultStack(), 250, ShopEntry.Type.WEAPON));`



This was originally from this [PR](https://github.com/doctor4t/TrainMurderMystery/commit/779a2829ece798ae37223fbae8683665968277e9#diff-45aa3cbaa0e8d249267012c7c11b1609c4f4c58f5720220a17151a61a23208eb), but it had other changes that seemed to break stuff.