### PR TITLE
Fix Knife Server Validation

### DIFF
--- a/src/main/java/dev/doctor4t/trainmurdermystery/util/KnifeStabPayload.java
+++ b/src/main/java/dev/doctor4t/trainmurdermystery/util/KnifeStabPayload.java
@@ -9,6 +9,7 @@ import dev.doctor4t.trainmurdermystery.index.TMMItems;
 import dev.doctor4t.trainmurdermystery.index.TMMSounds;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
 import net.minecraft.network.PacketByteBuf;
 import net.minecraft.network.codec.PacketCodec;
 import net.minecraft.network.codec.PacketCodecs;
@@ -30,6 +31,8 @@ public record KnifeStabPayload(int target) implements CustomPayload {
         @Override
         public void receive(@NotNull KnifeStabPayload payload, ServerPlayNetworking.@NotNull Context context) {
             ServerPlayerEntity player = context.player();
+            ItemStack mainHandStack = player.getMainHandStack();
+            if (!mainHandStack.isOf(TMMItems.KNIFE)) return;
             if (!(player.getServerWorld().getEntityById(payload.target()) instanceof PlayerEntity target)) return;
             if (target.distanceTo(player) > 3.0) return;
             GameFunctions.killPlayer(target, true, player, GameConstants.DeathReasons.KNIFE);

--- a/src/main/java/dev/doctor4t/trainmurdermystery/util/KnifeStabPayload.java
+++ b/src/main/java/dev/doctor4t/trainmurdermystery/util/KnifeStabPayload.java
@@ -33,6 +33,7 @@ public record KnifeStabPayload(int target) implements CustomPayload {
             ServerPlayerEntity player = context.player();
             ItemStack mainHandStack = player.getMainHandStack();
             if (!mainHandStack.isOf(TMMItems.KNIFE)) return;
+            if (player.getItemCooldownManager().isCoolingDown(mainHandStack.getItem())) return;
             if (!(player.getServerWorld().getEntityById(payload.target()) instanceof PlayerEntity target)) return;
             if (target.distanceTo(player) > 3.0) return;
             GameFunctions.killPlayer(target, true, player, GameConstants.DeathReasons.KNIFE);


### PR DESCRIPTION
The server currently does not check if the person is holding, allowing for anyone to create a mod that is able to find the player you're looking at and send a KnifeStabPayload allowing you to kill anyone without a knife or a cooldown.


https://github.com/user-attachments/assets/9653ab85-848f-4f3d-a017-d0664f53be8d

