### PR TITLE
Crowbar glass breaking mechanic

### DIFF
--- a/src/main/java/dev/doctor4t/trainmurdermystery/item/CrowbarItem.java
+++ b/src/main/java/dev/doctor4t/trainmurdermystery/item/CrowbarItem.java
@@ -2,38 +2,90 @@ package dev.doctor4t.trainmurdermystery.item;
 
 import dev.doctor4t.trainmurdermystery.block_entity.DoorBlockEntity;
 import dev.doctor4t.trainmurdermystery.game.GameConstants;
+import dev.doctor4t.trainmurdermystery.index.TMMBlocks;
 import dev.doctor4t.trainmurdermystery.index.TMMSounds;
 import dev.doctor4t.trainmurdermystery.util.AdventureUsable;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemUsageContext;
 import net.minecraft.sound.SoundCategory;
+import net.minecraft.sound.SoundEvents;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.Hand;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
 import net.minecraft.world.World;
 
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.HashSet;
+import java.util.Set;
+
 public class CrowbarItem extends Item implements AdventureUsable {
+
+    public Set<Block> glassBlocks = Set.of(
+            TMMBlocks.CULLING_GLASS,
+            TMMBlocks.HULL_GLASS,
+            TMMBlocks.RHOMBUS_GLASS,
+            TMMBlocks.GOLDEN_GLASS_PANEL,
+            TMMBlocks.PRIVACY_GLASS_PANEL,
+            TMMBlocks.RHOMBUS_HULL_GLASS
+    );
+
     public CrowbarItem(Settings settings) {
         super(settings);
     }
 
     @Override
     public ActionResult useOnBlock(ItemUsageContext context) {
+        boolean success = false;
         World world = context.getWorld();
-        BlockEntity entity = world.getBlockEntity(context.getBlockPos());
-        if (!(entity instanceof DoorBlockEntity)) entity = world.getBlockEntity(context.getBlockPos().down());
+        BlockPos blockPos = context.getBlockPos();
+        BlockEntity entity = world.getBlockEntity(blockPos);
         PlayerEntity player = context.getPlayer();
-        if (entity instanceof DoorBlockEntity door && !door.isBlasted() && player != null) {
-            if (!player.isCreative()) player.getItemCooldownManager().set(this, 6000);
-            world.playSound(null, context.getBlockPos(), TMMSounds.ITEM_CROWBAR_PRY, SoundCategory.BLOCKS, 2.5f, 1f);
-            player.swingHand(Hand.MAIN_HAND, true);
+        BlockState targetBlockState = world.getBlockState(blockPos);
 
-            if (!player.isCreative()) {
-                player.getItemCooldownManager().set(this, GameConstants.ITEM_COOLDOWNS.get(this));
+        if(player != null) {
+            if (!(entity instanceof DoorBlockEntity)) entity = world.getBlockEntity(context.getBlockPos().down());
+            if (entity instanceof DoorBlockEntity door && !door.isBlasted()) {
+                world.playSound(null, context.getBlockPos(), TMMSounds.ITEM_CROWBAR_PRY, SoundCategory.BLOCKS, 2.5f, 1f);
+                door.blast();
+                success = true;
+            } else if(targetBlockState != null) {
+                Set<BlockPos> checked = new HashSet<>();
+                Deque<BlockPos> toCheck = new ArrayDeque<>();
+                toCheck.push(blockPos);
+
+                while(!toCheck.isEmpty()) {
+                    BlockPos currentBlock = toCheck.pop();
+
+                    if(checked.contains(currentBlock)) continue;
+                    checked.add(currentBlock);
+
+                    if(!glassBlocks.contains(world.getBlockState(currentBlock).getBlock())) continue;
+                    world.playSound(null, currentBlock, SoundEvents.BLOCK_GLASS_BREAK, SoundCategory.BLOCKS, 1.0F, 1.0F);
+                    success = true;
+
+                    world.breakBlock(currentBlock, false);
+
+                    for(Direction direction : Direction.values()) {
+                        BlockPos nextBlockPos = currentBlock.offset(direction);
+                        if(!checked.contains(nextBlockPos)) {
+                            BlockState nextBlockState = world.getBlockState(nextBlockPos);
+                            if(glassBlocks.contains(nextBlockState.getBlock())) {
+                                toCheck.push(nextBlockPos);
+                            }
+                        }
+                    }
+                }
             }
-
-            door.blast();
+            if(success) {
+                player.swingHand(Hand.MAIN_HAND, true);
+                if (!player.isCreative()) player.getItemCooldownManager().set(this, GameConstants.ITEM_COOLDOWNS.get(this));
+            }
         }
         return super.useOnBlock(context);
     }


### PR DESCRIPTION
This pull request is focused on adding a new mechanic to the crowbar item. Addtionally to breaking doors, you can now also break windows. This works by right-clicking on a single glass type that was added by the mod which will result in all the adjacent glass blocks being broken.
Why should this be a feature of the mod? Because it allows for various new combinations that can be played as the killer. For instance alongside blackout together with psycho-mode. Furthermore, it poses a new threat to civilians that need some sleep, since the killers would be able to break their windows. This addtion would make stealthy kills more possible because who can find a body thats locked up in a room only the deceased person has access to?
Thank you for reading through this monstrosity of a description. I hope you may consider this feature to be implemented.